### PR TITLE
require throws a LoadError on Ruby 1.9.2 when it can't find core_ext/blank

### DIFF
--- a/lib/graft/xml.rb
+++ b/lib/graft/xml.rb
@@ -7,7 +7,7 @@ require 'tzinfo'
 begin
   # ActiveSupport < 2.3.5
   require 'active_support/core_ext/blank'
-rescue NameError
+rescue LoadError, NameError
   # ActiveSupport >= 2.3.5 will raise a NameError exception
   require 'active_support/core_ext/object/blank'
 end


### PR DESCRIPTION
require throws a LoadError on Ruby 1.9.2 when it can't find core_ext/blank
